### PR TITLE
We finally have typed object reference

### DIFF
--- a/BitButterCORE.V2.Testing/Event/EventManagerTest.cs
+++ b/BitButterCORE.V2.Testing/Event/EventManagerTest.cs
@@ -28,8 +28,8 @@ namespace BitButterCORE.V2.Testing
 
 			Assert.That(handlers.ContainsKey("TestEvent"), Is.True, "Should contain handler for TestEvent");
 			Assert.That(handlers["TestEvent"].Count, Is.EqualTo(2), "Should contain 2 handlers for TestEvent");
-			Assert.That(handlers["TestEvent"].Exists(tuple => (ObjectReference)tuple.Item1 == dummyObject1), Is.True, "Should contain handler targeting dummyObject1");
-			Assert.That(handlers["TestEvent"].Exists(tuple => (ObjectReference)tuple.Item1 == dummyObject2), Is.True, "Should contain handler targeting dummyObject2");
+			Assert.That(handlers["TestEvent"].Exists(tuple => (IObjectReference<DummyObjectWithEventHandler>)tuple.Item1 == dummyObject1), Is.True, "Should contain handler targeting dummyObject1");
+			Assert.That(handlers["TestEvent"].Exists(tuple => (IObjectReference<DummyObjectWithEventHandler>)tuple.Item1 == dummyObject2), Is.True, "Should contain handler targeting dummyObject2");
 		}
 
 		[Test]
@@ -41,14 +41,14 @@ namespace BitButterCORE.V2.Testing
 			EventManager.Instance.RaiseEvent("TestEvent");
 
 			Assert.That(DummyObjectWithEventHandler.TotalUpdateCalledCount, Is.EqualTo(2), "TestEvent handler should be invoked twice, once for each dummyObject");
-			Assert.That((dummyObject1.Object as DummyObjectWithEventHandler).UpdateCalledCount, Is.EqualTo(1), "TestEvent handler is invoked once for dummyObject1");
-			Assert.That((dummyObject2.Object as DummyObjectWithEventHandler).UpdateCalledCount, Is.EqualTo(1), "TestEvent handler is invoked once for dummyObject2");
+			Assert.That((dummyObject1.Object).UpdateCalledCount, Is.EqualTo(1), "TestEvent handler is invoked once for dummyObject1");
+			Assert.That((dummyObject2.Object).UpdateCalledCount, Is.EqualTo(1), "TestEvent handler is invoked once for dummyObject2");
 
 			ObjectFactory.Instance.Remove(dummyObject2);
 			EventManager.Instance.RaiseEvent("TestEvent");
 
 			Assert.That(DummyObjectWithEventHandler.TotalUpdateCalledCount, Is.EqualTo(3), "TestEvent handler should be invoked 3 times as handler for dummyPbject2 is not invoked");
-			Assert.That((dummyObject1.Object as DummyObjectWithEventHandler).UpdateCalledCount, Is.EqualTo(2), "TestEvent handler is invoked twice for dummyObject1");
+			Assert.That((dummyObject1.Object).UpdateCalledCount, Is.EqualTo(2), "TestEvent handler is invoked twice for dummyObject1");
 		}
 
 		[Test]
@@ -60,8 +60,8 @@ namespace BitButterCORE.V2.Testing
 			EventManager.Instance.RaiseEvent("TestEvent", 1, 2);
 
 			Assert.That(DummyObjectWithEventHandler.TotalUpdateCalledCount, Is.EqualTo(3), "TestEvent handler should be invoked 3 times");
-			Assert.That((dummyObject1.Object as DummyObjectWithEventHandler).UpdateCalledCount, Is.EqualTo(1), "TestEvent handler is invoked once for dummyObject1");
-			Assert.That((dummyObject2.Object as DummyObjectWithEventHandler).UpdateCalledCount, Is.EqualTo(2), "TestEvent handler is invoked twice for dummyObject2");
+			Assert.That((dummyObject1.Object).UpdateCalledCount, Is.EqualTo(1), "TestEvent handler is invoked once for dummyObject1");
+			Assert.That((dummyObject2.Object).UpdateCalledCount, Is.EqualTo(2), "TestEvent handler is invoked twice for dummyObject2");
 		}
 
 		[Test]
@@ -75,16 +75,16 @@ namespace BitButterCORE.V2.Testing
 
 			Assert.That(handlers.ContainsKey("TestEvent"), Is.True, "Should contain handler for TestEvent");
 			Assert.That(handlers["TestEvent"].Count, Is.EqualTo(2), "Should contain 2 handlers for TestEvent");
-			Assert.That(handlers["TestEvent"].Exists(tuple => (ObjectReference)tuple.Item1 == dummyObject1), Is.True, "Should contain handler targeting dummyObject1");
-			Assert.That(handlers["TestEvent"].Exists(tuple => (ObjectReference)tuple.Item1 == dummyObject2), Is.True, "Should contain handler targeting dummyObject2");
+			Assert.That(handlers["TestEvent"].Exists(tuple => (IObjectReference<DummyObjectWithEventHandler>)tuple.Item1 == dummyObject1), Is.True, "Should contain handler targeting dummyObject1");
+			Assert.That(handlers["TestEvent"].Exists(tuple => (IObjectReference<DummyObjectWithEventHandler>)tuple.Item1 == dummyObject2), Is.True, "Should contain handler targeting dummyObject2");
 
 			ObjectFactory.Instance.Remove(dummyObject2);
 			EventManager.Instance.RaiseEvent("TestEvent");
 
 			Assert.That(handlers.ContainsKey("TestEvent"), Is.True, "Should contain handler for TestEvent");
 			Assert.That(handlers["TestEvent"].Count, Is.EqualTo(1), "Should contain 1 handler for TestEvent, as handler for dummyObject2 is removed");
-			Assert.That(handlers["TestEvent"].Exists(tuple => (ObjectReference)tuple.Item1 == dummyObject1), Is.True, "Should contain handler targeting dummyObject1");
-			Assert.That(handlers["TestEvent"].Exists(tuple => (ObjectReference)tuple.Item1 == dummyObject2), Is.False, "Should not contain handler targeting dummyObject2");
+			Assert.That(handlers["TestEvent"].Exists(tuple => (IObjectReference<DummyObjectWithEventHandler>)tuple.Item1 == dummyObject1), Is.True, "Should contain handler targeting dummyObject1");
+			Assert.That(handlers["TestEvent"].Exists(tuple => (IObjectReference<DummyObjectWithEventHandler>)tuple.Item1 == dummyObject2), Is.False, "Should not contain handler targeting dummyObject2");
 		}
 
 		[Test]

--- a/BitButterCORE.V2.Testing/Factory/ObjectFactoryTest.cs
+++ b/BitButterCORE.V2.Testing/Factory/ObjectFactoryTest.cs
@@ -61,6 +61,13 @@ namespace BitButterCORE.V2.Testing
 		}
 
 		[Test]
+		public void TestCreateWithNullParameter()
+		{
+			var objectReference = ObjectFactory.Instance.Create<DummyObjectWithNullableParameterInConstructor>(new object[] { null });
+			Assert.That(objectReference.IsValid, Is.True, "Create object with null parameter should not fail");
+		}
+
+		[Test]
 		public void TestCreateWithTypeParameter()
 		{
 			var objectReference = ObjectFactory.Instance.Create(typeof(DummyObject));

--- a/BitButterCORE.V2.Testing/Factory/ObjectFactoryTest.cs
+++ b/BitButterCORE.V2.Testing/Factory/ObjectFactoryTest.cs
@@ -43,10 +43,10 @@ namespace BitButterCORE.V2.Testing
 		public void TestCreateWithDefaultParameter()
 		{
 			var objectReferenceWithDefaultParam = ObjectFactory.Instance.Create<DummyObjectWithDefaultParameterInConstructor>();
-			Assert.That(objectReferenceWithDefaultParam.GetObject<DummyObjectWithDefaultParameterInConstructor>().DefaultParam, Is.EqualTo(1), "DefaultParam should be default value 1");
+			Assert.That(objectReferenceWithDefaultParam.Object.DefaultParam, Is.EqualTo(1), "DefaultParam should be default value 1");
 
 			var objectReferenceWithExplicitParam = ObjectFactory.Instance.Create<DummyObjectWithDefaultParameterInConstructor>(2);
-			Assert.That(objectReferenceWithExplicitParam.GetObject<DummyObjectWithDefaultParameterInConstructor>().DefaultParam, Is.EqualTo(2), "DefaultParam should be explicit value 2");
+			Assert.That(objectReferenceWithExplicitParam.Object.DefaultParam, Is.EqualTo(2), "DefaultParam should be explicit value 2");
 		}
 
 		[Test]
@@ -301,7 +301,7 @@ namespace BitButterCORE.V2.Testing
 
 			Assert.That(ObjectFactory.Instance.QueryFirst<DummyObject>().ID, Is.EqualTo(dummyObject1.ID), "Should find 1st dummy object");
 			Assert.That(ObjectFactory.Instance.QueryFirst<DummyObject>(obj => obj.ID == dummyObject2.ID).ID, Is.EqualTo(dummyObject2.ID), "Should find 2nd dummy object when query with predicate");
-			Assert.That(ObjectFactory.Instance.QueryFirst<DummyObject2>(), Is.EqualTo(default(ObjectReference)), "Should return default reference when no object is found");
+			Assert.That(ObjectFactory.Instance.QueryFirst<DummyObject2>(), Is.EqualTo(default(IObjectReference)), "Should return default reference when no object is found");
 		}
 	}
 }

--- a/BitButterCORE.V2.Testing/Object/BaseObjectTest.cs
+++ b/BitButterCORE.V2.Testing/Object/BaseObjectTest.cs
@@ -25,6 +25,7 @@ namespace BitButterCORE.V2.Testing
 		{
 			Assert.That(() => ObjectFactory.Instance.Create<DummyObject>(), Throws.Nothing, "Should throw no exception");
 			Assert.That(ObjectFactory.Instance.Create<DummyObject>().IsValid, Is.True, "Should return valid object reference");
+			Assert.That(ObjectFactory.Instance.Create<DummyObject>().GetType(), Is.EqualTo(typeof(ObjectReference<DummyObject>)), "Returned object reference should be typed");
 		}
 
 		[Test]
@@ -35,6 +36,18 @@ namespace BitButterCORE.V2.Testing
 
 			var object2 = ObjectFactory.Instance.Create<DummyObject>().Object;
 			Assert.That(object2.ID, Is.EqualTo(2), "object2 should have ID equal to 2");
+		}
+
+		[Test]
+		public void TestTypedReference()
+		{
+			var baseObject = ObjectFactory.Instance.Create<DummyObject>().Object;
+			Assert.That(baseObject.TypedReference.GetType(), Is.EqualTo(typeof(ObjectReference<DummyObject>)), "TypedReference of baseObject should be of correct type");
+			Assert.That(baseObject.TypedReference.Object, Is.EqualTo(baseObject), "TypedReference should return baseObject");
+
+			var derivedObject = ObjectFactory.Instance.Create<DerivedDummyObject>().Object;
+			Assert.That(derivedObject.TypedReference.GetType(), Is.EqualTo(typeof(ObjectReference<DerivedDummyObject>)), "TypedReference of derivedObject should be of correct type");
+			Assert.That(derivedObject.TypedReference.Object, Is.EqualTo(derivedObject), "TypedReference should return derivedObject");
 		}
 
 		[Test]

--- a/BitButterCORE.V2.Testing/Object/DummyObject.cs
+++ b/BitButterCORE.V2.Testing/Object/DummyObject.cs
@@ -1,6 +1,6 @@
 ﻿namespace BitButterCORE.V2.Testing
 {
-	public class DummyObject : BaseObject
+	public class DummyObject : BaseObject<DummyObject>
 	{
 		public DummyObject(uint id)
 			: base(id)
@@ -10,7 +10,7 @@
 		public string Name => string.Format("DummyObject{0}", ID);
 	}
 
-	public class DummyObject2 : BaseObject
+	public class DummyObject2 : BaseObject<DummyObject2>
 	{
 		public DummyObject2(uint id)
 			: base(id)
@@ -20,7 +20,15 @@
 		public string Name => "DummyObject2";
 	}
 
-	public class DummyObjectWithDefaultParameterInConstructor : BaseObject
+	public class DerivedDummyObject : DummyObject
+	{
+		public DerivedDummyObject(uint id)
+			: base(id)
+		{
+		}
+	}
+
+	public class DummyObjectWithDefaultParameterInConstructor : BaseObject<DummyObjectWithDefaultParameterInConstructor>
 	{
 		public DummyObjectWithDefaultParameterInConstructor(uint id, int defaultParam = 1)
 			: base(id)
@@ -31,7 +39,7 @@
 		public int DefaultParam { get; }
 	}
 
-	public class DummyObjectWithMultipleConstructor : BaseObject
+	public class DummyObjectWithMultipleConstructor : BaseObject<DummyObjectWithMultipleConstructor>
 	{
 		public DummyObjectWithMultipleConstructor(uint id)
 			: base(id)
@@ -44,7 +52,7 @@
 		}
 	}
 
-	public class DummyObjectWithEventHandler : BaseObject
+	public class DummyObjectWithEventHandler : BaseObject<DummyObjectWithEventHandler>
 	{
 		public DummyObjectWithEventHandler(uint id)
 			: base(id)

--- a/BitButterCORE.V2.Testing/Object/DummyObject.cs
+++ b/BitButterCORE.V2.Testing/Object/DummyObject.cs
@@ -52,6 +52,14 @@
 		}
 	}
 
+	public class DummyObjectWithNullableParameterInConstructor : BaseObject<DummyObjectWithNullableParameterInConstructor>
+	{
+		public DummyObjectWithNullableParameterInConstructor(uint id, object obj)
+			: base(id)
+		{
+		}
+	}
+
 	public class DummyObjectWithEventHandler : BaseObject<DummyObjectWithEventHandler>
 	{
 		public DummyObjectWithEventHandler(uint id)

--- a/BitButterCORE.V2.Testing/Object/ObjectReferenceTest.cs
+++ b/BitButterCORE.V2.Testing/Object/ObjectReferenceTest.cs
@@ -19,6 +19,9 @@ namespace BitButterCORE.V2.Testing
 
 			var objectReference2 = ObjectFactory.Instance.Create<DummyObject2>();
 			Assert.That(objectReference2.Type, Is.EqualTo(typeof(DummyObject2)));
+
+			var objectReference3 = ObjectFactory.Instance.Create<DerivedDummyObject>();
+			Assert.That(objectReference3.Type, Is.EqualTo(typeof(DerivedDummyObject)));
 		}
 
 		[Test]
@@ -45,26 +48,6 @@ namespace BitButterCORE.V2.Testing
 		}
 
 		[Test]
-		public void TestGetObject()
-		{
-			var defaultReference = default(ObjectReference);
-			Assert.That(defaultReference.GetObject<DummyObject>(), Is.Null, "Default reference should return null");
-
-			var objectReference = ObjectFactory.Instance.Create<DummyObject>();
-			Assert.That(objectReference.GetObject<DummyObject2>(), Is.Null, "Should return null when generic type is not matched");
-
-			var dummyObject = objectReference.GetObject<DummyObject>();
-			Assert.That(dummyObject, Is.Not.Null, "Should return non-null object");
-			Assert.That(dummyObject.GetType(), Is.EqualTo(typeof(DummyObject)), "Object type should be DummyObject instead of BaseObject");
-			Assert.That(dummyObject.ID, Is.EqualTo(objectReference.Object.ID), "Object ID should match that returned by Object property");
-
-			var baseObject = objectReference.GetObject<BaseObject>();
-			Assert.That(baseObject, Is.Not.Null, "Should return non-null object when generic type is the base class type");
-			Assert.That(baseObject.GetType(), Is.EqualTo(typeof(DummyObject)), "Object type should be DummyObject instead of BaseObject");
-			Assert.That(baseObject.ID, Is.EqualTo(objectReference.Object.ID), "Object ID should match that returned by Object property");
-		}
-
-		[Test]
 		public void TestIsValid()
 		{
 			var objectReference = ObjectFactory.Instance.Create<DummyObject>();
@@ -75,20 +58,9 @@ namespace BitButterCORE.V2.Testing
 		}
 
 		[Test]
-		public void TestIsValidByTypeAndID()
-		{
-			var objectReference = ObjectFactory.Instance.Create<DummyObject>();
-
-			Assert.That(objectReference.IsValidByTypeAndID<DummyObject>(2), Is.False, "Should be non valid when ID is not correct");
-			Assert.That(objectReference.IsValidByTypeAndID<DummyObject2>(1), Is.False, "Should be non valid when type is not correct");
-			Assert.That(objectReference.IsValidByTypeAndID<DummyObject>(1), Is.True, "Should be valid when both type and ID are correct");
-			Assert.That(objectReference.IsValidByTypeAndID<BaseObject>(1), Is.True, "Should be valid when checking against base class type");
-		}
-
-		[Test]
 		public void TestDefaultObjectReferenceIsInvalid()
 		{
-			var defaultReference = default(ObjectReference);
+			var defaultReference = default(ObjectReference<BaseObject>);
 			Assert.That(defaultReference.IsValid, Is.False, "Default reference is not valid");
 		}
 	}

--- a/BitButterCORE.V2/Event/EventManager.cs
+++ b/BitButterCORE.V2/Event/EventManager.cs
@@ -14,7 +14,7 @@ namespace BitButterCORE.V2
 				{
 					var target = handler.Item1;
 					var args = eventArgs.Length > 0 ? new object[] { eventArgs } : new object[] { null };
-					if (target is ObjectReference reference)
+					if (target is IObjectReference reference)
 					{
 						if (reference.IsValid)
 						{
@@ -34,7 +34,7 @@ namespace BitButterCORE.V2
 		bool ShouldRemoveHandler(Tuple<object, MethodInfo> handlerTuple)
 		{
 			var result = false;
-			if (handlerTuple.Item1 is ObjectReference reference)
+			if (handlerTuple.Item1 is IObjectReference reference)
 			{
 				result = !reference.IsValid;
 			}

--- a/BitButterCORE.V2/Factory/ObjectFactory.cs
+++ b/BitButterCORE.V2/Factory/ObjectFactory.cs
@@ -7,14 +7,14 @@ namespace BitButterCORE.V2
 {
 	public class ObjectFactory : BaseSingleton<ObjectFactory>
 	{
-		public ObjectReference Create<TObject>(params object[] args) where TObject : BaseObject
+		public IObjectReference<TObject> Create<TObject>(params object[] args) where TObject : BaseObject
 		{
-			return Create(typeof(TObject), args);
+			return (IObjectReference<TObject>)Create(typeof(TObject), args);
 		}
 
-		public ObjectReference Create(Type objectType, params object[] args)
+		public IObjectReference Create(Type objectType, params object[] args)
 		{
-			var result = default(ObjectReference);
+			var result = default(IObjectReference);
 			if (!objectType.IsAbstract)
 			{
 				var newID = GetObjectIDFountain(objectType).NextID;
@@ -88,7 +88,7 @@ namespace BitButterCORE.V2
 			});
 		}
 
-		public void Remove(ObjectReference reference)
+		public void Remove(IObjectReference reference)
 		{
 			var objectToRemove = GetObjectByReference(reference);
 			if (objectToRemove != null)
@@ -148,12 +148,12 @@ namespace BitButterCORE.V2
 			RemovedObjects.Clear();
 		}
 
-		void UpdateFactoryChangeRecordsForAddObject(ObjectReference reference)
+		void UpdateFactoryChangeRecordsForAddObject(IObjectReference reference)
 		{
 			AddObjectReferenceToFactoryChangeRecords(reference, AddedObjects);
 		}
 
-		void UpdateFactoryChangeRecordsForRemoveObject(ObjectReference reference)
+		void UpdateFactoryChangeRecordsForRemoveObject(IObjectReference reference)
 		{
 			var objectType = reference.Type;
 			if (AddedObjects.ContainsKey(objectType) && addedObjects[objectType].Contains(reference))
@@ -170,35 +170,35 @@ namespace BitButterCORE.V2
 			}
 		}
 
-		void AddObjectReferenceToFactoryChangeRecords(ObjectReference reference, Dictionary<Type, List<ObjectReference>> factoryChangeRecords)
+		void AddObjectReferenceToFactoryChangeRecords(IObjectReference reference, Dictionary<Type, List<IObjectReference>> factoryChangeRecords)
 		{
 			var objectType = reference.Type;
 			if (!factoryChangeRecords.ContainsKey(objectType))
 			{
-				factoryChangeRecords.Add(objectType, new List<ObjectReference>());
+				factoryChangeRecords.Add(objectType, new List<IObjectReference>());
 			}
 			factoryChangeRecords[objectType].Add(reference);
 		}
 
-		public IEnumerable<ObjectReference> GetAddedObjects()
+		public IEnumerable<IObjectReference> GetAddedObjects()
 		{
 			return AddedObjects.SelectMany(x => x.Value);
 		}
 
-		public IEnumerable<ObjectReference> GetRemovedObjects()
+		public IEnumerable<IObjectReference> GetRemovedObjects()
 		{
 			return RemovedObjects.SelectMany(x => x.Value);
 		}
 
-		Dictionary<Type, List<ObjectReference>> AddedObjects => addedObjects ?? (addedObjects = new Dictionary<Type, List<ObjectReference>>());
-		Dictionary<Type, List<ObjectReference>> addedObjects;
+		Dictionary<Type, List<IObjectReference>> AddedObjects => addedObjects ?? (addedObjects = new Dictionary<Type, List<IObjectReference>>());
+		Dictionary<Type, List<IObjectReference>> addedObjects;
 
-		Dictionary<Type, List<ObjectReference>> RemovedObjects => removedObjects ?? (removedObjects = new Dictionary<Type, List<ObjectReference>>());
-		Dictionary<Type, List<ObjectReference>> removedObjects;
+		Dictionary<Type, List<IObjectReference>> RemovedObjects => removedObjects ?? (removedObjects = new Dictionary<Type, List<IObjectReference>>());
+		Dictionary<Type, List<IObjectReference>> removedObjects;
 
-		internal bool HasObjectWithReference(ObjectReference reference) => Factory.ContainsKey(reference.Type) && Factory[reference.Type].ContainsKey(reference.ID);
+		internal bool HasObjectWithReference(IObjectReference reference) => Factory.ContainsKey(reference.Type) && Factory[reference.Type].ContainsKey(reference.ID);
 
-		internal BaseObject GetObjectByReference(ObjectReference reference) => GetObjectByTypeAndID(reference.Type, reference.ID);
+		internal BaseObject GetObjectByReference(IObjectReference reference) => GetObjectByTypeAndID(reference.Type, reference.ID);
 
 		BaseObject GetObjectByTypeAndID(Type type, uint id)
 		{
@@ -210,7 +210,7 @@ namespace BitButterCORE.V2
 			return result;
 		}
 
-		public IEnumerable<ObjectReference> Query<TObject>(Predicate<TObject> predicate = null) where TObject : BaseObject
+		public IEnumerable<IObjectReference<TObject>> Query<TObject>(Predicate<TObject> predicate = null) where TObject : BaseObject
 		{
 			var objectType = typeof(TObject);
 			var objectCollection = new List<TObject>();
@@ -235,13 +235,13 @@ namespace BitButterCORE.V2
 					var queryResult = predicate?.Invoke(obj) ?? true;
 					if (queryResult)
 					{
-						yield return obj.Reference;
+						yield return (IObjectReference<TObject>)obj.Reference;
 					}
 				}
 			}
 		}
 
-		public ObjectReference QueryFirst<TObject>(Predicate<TObject> predicate = null) where TObject : BaseObject => Query(predicate).FirstOrDefault();
+		public IObjectReference<TObject> QueryFirst<TObject>(Predicate<TObject> predicate = null) where TObject : BaseObject => Query(predicate).FirstOrDefault();
 
 		void AddObjectToFactory(BaseObject objectToAdd)
 		{

--- a/BitButterCORE.V2/Factory/ObjectFactory.cs
+++ b/BitButterCORE.V2/Factory/ObjectFactory.cs
@@ -64,7 +64,7 @@ namespace BitButterCORE.V2
 							{
 								var inputParameter = inputParameters.ElementAt(inputParameterIndex);
 								var parameterType = parameter.ParameterType;
-								if (!parameterType.IsAssignableFrom(inputParameter.GetType()))
+								if (inputParameter != null && !parameterType.IsAssignableFrom(inputParameter.GetType()))
 								{
 									result = false;
 								}

--- a/BitButterCORE.V2/Object/BaseObject.cs
+++ b/BitButterCORE.V2/Object/BaseObject.cs
@@ -4,10 +4,16 @@ namespace BitButterCORE.V2
 {
 	public abstract class BaseObject
 	{
+		public abstract uint ID { get; }
+		public abstract IObjectReference Reference { get; }
+	}
+
+	public abstract class BaseObject<TObject> : BaseObject where TObject : BaseObject
+	{
 		protected BaseObject(uint id)
 		{
 			ID = id;
-			Reference = new ObjectReference(GetType(), ID);
+			TypedReference = CreateTypedReference();
 
 			if (!ObjectFactory.Instance.IsObjectIDUsed(GetType(), ID))
 			{
@@ -15,9 +21,17 @@ namespace BitButterCORE.V2
 			}
 		}
 
-		public uint ID { get; }
+		IObjectReference<TObject> CreateTypedReference()
+		{
+			var referenceType = typeof(ObjectReference<>).MakeGenericType(GetType());
+			return (IObjectReference<TObject>)Activator.CreateInstance(referenceType, ID);
+		}
 
-		public ObjectReference Reference { get; }
+		public override uint ID { get; }
+
+		public IObjectReference<TObject> TypedReference { get; }
+
+		public override IObjectReference Reference => TypedReference;
 
 		public override string ToString()
 		{


### PR DESCRIPTION
ObjectReference is now generic struct ObjectReference<TObject>.
Its property Object can now return instance of derived class of BaseObject without explicit cast.